### PR TITLE
Add support for HAProxy to PXC-57 !

### DIFF
--- a/pxc-57/Dockerfile
+++ b/pxc-57/Dockerfile
@@ -5,8 +5,14 @@ RUN groupadd -r mysql && useradd -r -g mysql mysql
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
 		apt-transport-https ca-certificates \
-		pwgen wget \
+		pwgen wget xinetd \
 	&& rm -rf /var/lib/apt/lists/*
+
+# [elouizbadr] : 
+# 1- Added "xinetd" on line 8 to install X Internet Services.
+# 2- Added following line to install MySQLCheck service to work with HAProxy configuration.
+RUN echo "mysqlchk	9200/tcp" >> /etc/services && service xinetd restart
+####################################################################################################
 
 RUN wget https://repo.percona.com/apt/percona-release_0.1-4.jessie_all.deb \
   && dpkg -i percona-release_0.1-4.jessie_all.deb

--- a/pxc-57/Dockerfile
+++ b/pxc-57/Dockerfile
@@ -11,7 +11,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 # [elouizbadr] : 
 # 1- Added "xinetd" on line 8 to install X Internet Services.
 # 2- Added following line to install MySQLCheck service to work with HAProxy configuration.
-RUN echo "mysqlchk	9200/tcp" >> /etc/services && service xinetd restart
+RUN echo "mysqlchk	9200/tcp" >> /etc/services && /etc/init.d/xinetd start
 ####################################################################################################
 
 RUN wget https://repo.percona.com/apt/percona-release_0.1-4.jessie_all.deb \

--- a/pxc-57/Dockerfile
+++ b/pxc-57/Dockerfile
@@ -11,7 +11,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 # [elouizbadr] : 
 # 1- Added "xinetd" on line 8 to install X Internet Services.
 # 2- Added following line to install MySQLCheck service to work with HAProxy configuration.
-RUN echo "mysqlchk	9200/tcp" >> /etc/services && /etc/init.d/xinetd start
+RUN echo "mysqlchk	9200/tcp" >> /etc/services
 ####################################################################################################
 
 RUN wget https://repo.percona.com/apt/percona-release_0.1-4.jessie_all.deb \

--- a/pxc-57/entrypoint.sh
+++ b/pxc-57/entrypoint.sh
@@ -156,6 +156,9 @@ set -e
 
 fi
 
+# [elouizbadr] : Launch xinetd service for HAProxy
+/etc/init.d/xinetd start
+
 #--log-error=${DATADIR}error.log
 exec mysqld --user=mysql --wsrep_cluster_name=$CLUSTER_NAME --wsrep_cluster_address="gcomm://$cluster_join" --wsrep_sst_method=xtrabackup-v2 --wsrep_sst_auth="xtrabackup:$XTRABACKUP_PASSWORD" --wsrep_node_address="$ipaddr" $CMDARG
 

--- a/pxc-57/entrypoint.sh
+++ b/pxc-57/entrypoint.sh
@@ -64,6 +64,9 @@ fi
 			GRANT REPLICATION CLIENT ON *.* TO monitor@'%' IDENTIFIED BY 'monitor';
 			GRANT PROCESS ON *.* TO monitor@localhost IDENTIFIED BY 'monitor';
 			DROP DATABASE IF EXISTS test ;
+			-- [elouizbadr] :
+			-- Add CLusterCheck script username/password to work with HAProxy
+			GRANT PROCESS ON *.* TO clustercheckuser@'%' IDENTIFIED BY 'clustercheckpassword!';			
 			FLUSH PRIVILEGES ;
 		EOSQL
 		if [ ! -z "$MYSQL_ROOT_PASSWORD" ]; then


### PR DESCRIPTION
Hi,

my two commits in this PR make this image able to be used seamlessly with HAProxy.
My commits do the following : 
1- Install and start "xinetd" service to be used by MYSQLCHK service that uses CLUSTERCHECK percona script to provide healthcheck for HAProxy.
2- Add MYSQLCHK service to "/etc/services".
3- Create default CLUSTERCHECK user account on MySQL instance.

Thanks!